### PR TITLE
Problem: l2 gas price is not adjusted with the exchange rate of CRO

### DIFF
--- a/core/node/fee_model/src/lib.rs
+++ b/core/node/fee_model/src/lib.rs
@@ -64,6 +64,7 @@ pub struct MainNodeFeeInputProvider {
 
 impl BatchFeeModelInputProvider for MainNodeFeeInputProvider {
     fn get_fee_model_params(&self) -> FeeParams {
+        let constant_base_token_exchange_rate: u64 = 40000;
         match self.config {
             FeeModelConfig::V1(config) => FeeParams::V1(FeeParamsV1 {
                 config,
@@ -71,8 +72,10 @@ impl BatchFeeModelInputProvider for MainNodeFeeInputProvider {
             }),
             FeeModelConfig::V2(config) => FeeParams::V2(FeeParamsV2 {
                 config,
-                l1_gas_price: self.provider.estimate_effective_gas_price(),
-                l1_pubdata_price: self.provider.estimate_effective_pubdata_price(),
+                l1_gas_price: self.provider.estimate_effective_gas_price()
+                    * constant_base_token_exchange_rate,
+                l1_pubdata_price: self.provider.estimate_effective_pubdata_price()
+                    * constant_base_token_exchange_rate,
             }),
         }
     }


### PR DESCRIPTION
Solution: Use a constant multiplier as a temporary solution while the Oracle solution is still under development 
