### PR TITLE
feat: Add eth sender signing mode

### DIFF
--- a/core/lib/config/src/configs/eth_sender.rs
+++ b/core/lib/config/src/configs/eth_sender.rs
@@ -42,6 +42,7 @@ impl EthConfig {
                 max_acceptable_priority_fee_in_gwei: 100000000000,
                 proof_loading_mode: ProofLoadingMode::OldProofFromDb,
                 pubdata_sending_mode: PubdataSendingMode::Calldata,
+                signing_mode: SigningMode::PrivateKey,
             }),
             gas_adjuster: Some(GasAdjusterConfig {
                 default_priority_fee_per_gas: 1000000000,
@@ -86,6 +87,13 @@ pub enum PubdataSendingMode {
     Blobs,
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Default)]
+pub enum SigningMode {
+    #[default]
+    PrivateKey,
+    GcloudKms,
+}
+
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct SenderConfig {
     pub aggregated_proof_sizes: Vec<usize>,
@@ -122,6 +130,9 @@ pub struct SenderConfig {
 
     /// The mode in which we send pubdata, either Calldata or Blobs
     pub pubdata_sending_mode: PubdataSendingMode,
+
+    /// Type of signing client for Ethereum transactions.
+    pub signing_mode: SigningMode,
 }
 
 impl SenderConfig {

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -6,7 +6,10 @@ use zksync_basic_types::{
 };
 use zksync_consensus_utils::EncodeDist;
 
-use crate::configs::{self, eth_sender::PubdataSendingMode};
+use crate::configs::{
+    self,
+    eth_sender::{PubdataSendingMode, SigningMode},
+};
 
 trait Sample {
     fn sample(rng: &mut (impl Rng + ?Sized)) -> Self;
@@ -384,6 +387,7 @@ impl Distribution<configs::eth_sender::SenderConfig> for EncodeDist {
             max_acceptable_priority_fee_in_gwei: self.sample(rng),
             proof_loading_mode: self.sample(rng),
             pubdata_sending_mode: PubdataSendingMode::Calldata,
+            signing_mode: SigningMode::PrivateKey,
         }
     }
 }

--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -34,7 +34,7 @@ impl FromEnv for GasAdjusterConfig {
 #[cfg(test)]
 mod tests {
     use zksync_config::configs::eth_sender::{
-        ProofLoadingMode, ProofSendingMode, PubdataSendingMode,
+        ProofLoadingMode, ProofSendingMode, PubdataSendingMode, SigningMode,
     };
 
     use super::*;
@@ -64,6 +64,7 @@ mod tests {
                 max_acceptable_priority_fee_in_gwei: 100_000_000_000,
                 proof_loading_mode: ProofLoadingMode::OldProofFromDb,
                 pubdata_sending_mode: PubdataSendingMode::Calldata,
+                signing_mode: SigningMode::PrivateKey,
             }),
             gas_adjuster: Some(GasAdjusterConfig {
                 default_priority_fee_per_gas: 20000000000,
@@ -123,6 +124,7 @@ mod tests {
             ETH_SENDER_SENDER_MAX_ACCEPTABLE_PRIORITY_FEE_IN_GWEI="100000000000"
             ETH_SENDER_SENDER_PROOF_LOADING_MODE="OldProofFromDb"
             ETH_SENDER_SENDER_PUBDATA_SENDING_MODE="Calldata"
+            ETH_SENDER_SENDER_SIGNING_MODE="PrivateKey"
             ETH_CLIENT_WEB3_URL="http://127.0.0.1:8545"
 
         "#;

--- a/core/lib/protobuf_config/src/eth.rs
+++ b/core/lib/protobuf_config/src/eth.rs
@@ -60,6 +60,24 @@ impl proto::PubdataSendingMode {
     }
 }
 
+impl proto::SigningMode {
+    fn new(x: &configs::eth_sender::SigningMode) -> Self {
+        use configs::eth_sender::SigningMode as From;
+        match x {
+            From::PrivateKey => Self::PrivateKey,
+            From::GcloudKms => Self::GcloudKms,
+        }
+    }
+
+    fn parse(&self) -> configs::eth_sender::SigningMode {
+        use configs::eth_sender::SigningMode as To;
+        match self {
+            Self::PrivateKey => To::PrivateKey,
+            Self::GcloudKms => To::GcloudKms,
+        }
+    }
+}
+
 impl ProtoRepr for proto::Eth {
     type Type = configs::eth_sender::EthConfig;
 
@@ -136,6 +154,10 @@ impl ProtoRepr for proto::Sender {
                 .and_then(|x| Ok(proto::ProofLoadingMode::try_from(*x)?))
                 .context("proof_loading_mode")?
                 .parse(),
+            signing_mode: required(&self.signing_mode)
+                .and_then(|x| Ok(proto::SigningMode::try_from(*x)?))
+                .context("signing_mode")?
+                .parse(),
         })
     }
 
@@ -167,6 +189,7 @@ impl ProtoRepr for proto::Sender {
                 proto::PubdataSendingMode::new(&this.pubdata_sending_mode).into(),
             ),
             proof_loading_mode: Some(proto::ProofLoadingMode::new(&this.proof_loading_mode).into()),
+            signing_mode: Some(proto::SigningMode::new(&this.signing_mode).into()),
         }
     }
 }

--- a/core/lib/protobuf_config/src/proto/config/eth_sender.proto
+++ b/core/lib/protobuf_config/src/proto/config/eth_sender.proto
@@ -25,6 +25,11 @@ enum PubdataSendingMode {
   BLOBS = 1;
 }
 
+enum SigningMode {
+  PRIVATE_KEY = 0;
+  GCLOUD_KMS = 1;
+}
+
 message Sender {
   repeated uint64 aggregated_proof_sizes = 1; // ?
   optional uint64 wait_confirmations = 2; // optional
@@ -44,6 +49,7 @@ message Sender {
   optional uint64 max_acceptable_priority_fee_in_gwei = 16; // required; gwei
   optional PubdataSendingMode pubdata_sending_mode = 18; // required
   optional ProofLoadingMode proof_loading_mode = 19;
+  optional SigningMode signing_mode = 99; // required
 }
 
 message GasAdjuster {

--- a/etc/env/base/eth_sender.toml
+++ b/etc/env/base/eth_sender.toml
@@ -50,6 +50,8 @@ proof_loading_mode="FriProofFromGcs"
 
 pubdata_sending_mode = "Blobs"
 
+signing_mode = "PrivateKey"
+
 [eth_sender.gas_adjuster]
 # Priority fee to be used by GasAdjuster (in wei).
 default_priority_fee_per_gas = 1_000_000_000


### PR DESCRIPTION
Implemented signing mode in the eth sender config base on **https://github.com/cronos-labs/cronos-zkevm/pull/44#issuecomment-2216160509**

The default config in `dev.env` will be 
```
ETH_SENDER_SENDER_SIGNING_MODE=PrivateKey
```

For using google cloud kms signer, Please update the config to
```
ETH_SENDER_SENDER_SIGNING_MODE=GcloudKms
```