### PR TITLE
Problem: Operator address is not displayed when using GKMS

### DIFF
--- a/core/lib/eth_client/src/clients/http/signing.rs
+++ b/core/lib/eth_client/src/clients/http/signing.rs
@@ -51,15 +51,16 @@ impl GKMSSigningClient {
         query_client: Box<dyn EthInterface>,
         key_name: String,
     ) -> Self {
+        let operator_address = signer.get_address().await.expect("error getting operator address from signer");
         let signer = match GKMSSigner::new(key_name, l1_chain_id.0).await {
             Ok(s) => s,
             Err(e) => panic!("Failed to create GKMSSigner: {:?}", e),
         };
-
+        tracing::info!("Operator address: {operator_address:?}");
         SigningClient::new(
             query_client,
             hyperchain_contract(),
-            signer.get_address().await.unwrap(),
+            operator_address,
             signer,
             diamond_proxy_addr,
             default_priority_fee_per_gas.into(),

--- a/core/lib/eth_client/src/clients/http/signing.rs
+++ b/core/lib/eth_client/src/clients/http/signing.rs
@@ -51,11 +51,11 @@ impl GKMSSigningClient {
         query_client: Box<dyn EthInterface>,
         key_name: String,
     ) -> Self {
-        let operator_address = signer.get_address().await.expect("error getting operator address from signer");
         let signer = match GKMSSigner::new(key_name, l1_chain_id.0).await {
             Ok(s) => s,
             Err(e) => panic!("Failed to create GKMSSigner: {:?}", e),
         };
+        let operator_address = signer.get_address().await.expect("error getting operator address from signer");
         tracing::info!("Operator address: {operator_address:?}");
         SigningClient::new(
             query_client,


### PR DESCRIPTION
Solution: Display operator address on instantiation

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
