### PR TITLE
Problem: base_fee_per_gas and base_fee_per_blob_gas have different lengths error

### DIFF
--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -101,7 +101,7 @@ where
             let chunk_end = (chunk_start + MAX_REQUEST_CHUNK).min(upto_block);
             let chunk_size = chunk_end - chunk_start;
 
-            let fee_history = self
+            let mut fee_history = self
                 .fee_history(
                     U64::from(chunk_size),
                     web3::BlockNumber::from(chunk_end),
@@ -117,11 +117,8 @@ where
             // prior to EIP-4844.
             // https://ethereum.github.io/execution-apis/api-documentation/
             if fee_history.base_fee_per_gas.len() != fee_history.base_fee_per_blob_gas.len() {
-                tracing::error!(
-                    "base_fee_per_gas and base_fee_per_blob_gas have different lengths: {} and {}",
-                    fee_history.base_fee_per_gas.len(),
-                    fee_history.base_fee_per_blob_gas.len()
-                );
+                fee_history.base_fee_per_blob_gas =
+                    vec![U256::from(0); fee_history.base_fee_per_gas.len()];
             }
 
             for (base, blob) in fee_history


### PR DESCRIPTION
## What ❔

Some rpc provider does not return blob data for eth_history
We will use empty array instead

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
