### PR TITLE
fix: zkstack failed to run server

### DIFF
--- a/core/lib/config/src/configs/tx_sink.rs
+++ b/core/lib/config/src/configs/tx_sink.rs
@@ -10,6 +10,14 @@ pub struct TxSinkConfig {
 
 impl TxSinkConfig {
     pub fn deny_list(&self) -> Option<HashSet<Address>> {
+        // Return deny list is not set or empty
+        if self.deny_list.is_none() || self.deny_list.as_ref().unwrap().is_empty() {
+            return None;
+        }
+
+        // Parse deny list from a string and return it as a set of addresses
+        // Example: "0x1,0x2,0x3" -> { Address::from_str("0x1").unwrap(), Address::from_str("0x2").unwrap(), Address::from_str("0x3").unwrap() }
+        // Note: This assumes that the addresses are separated by commas and are in valid format.
         self.deny_list.as_ref().map(|list| {
             list.split(',')
                 .map(|element| Address::from_str(element).unwrap())

--- a/etc/env/file_based/general.yaml
+++ b/etc/env/file_based/general.yaml
@@ -108,6 +108,7 @@ eth:
     max_aggregated_tx_gas: 15000000
     max_acceptable_priority_fee_in_gwei: 100000000000
     pubdata_sending_mode: BLOBS
+    signing_mode: PRIVATE_KEY
     max_acceptable_base_fee_in_wei: 100000000000
   gas_adjuster:
     default_priority_fee_per_gas: 1000000000
@@ -383,3 +384,5 @@ consensus:
   public_addr: "127.0.0.1:3054"
   max_payload_size: 2500000
   gossip_dynamic_inbound_limit: 100
+tx_sink:
+  deny_list: ""


### PR DESCRIPTION
Fixes zkstack reference config settings missing configs for the cronos zkevm features.

Note:
When we run `zkstack chain init`, the script will copy the default config files from `etc/env/file_based` as a new chain config. Therefore, it will miss some configs relate to the cronos zkevm chain features. However, the zkstack seems like cannot read yaml file properly, so we need to set the value relate to our features no matter it's optional field (in proto file) or not.
