### PR TITLE
fix: wallet.yaml conflicts with gkms-signer settings

### DIFF
--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use anyhow::{bail, Context};
 use zksync_config::{
     configs::{
-        da_client::DAClientConfig, eth_sender::SigningMode, gateway::GatewayChainConfig,
-        secrets::DataAvailabilitySecrets, wallets::Wallets, GeneralConfig, Secrets,
+        da_client::DAClientConfig, gateway::GatewayChainConfig, secrets::DataAvailabilitySecrets,
+        wallets::Wallets, GeneralConfig, Secrets,
     },
     ContractsConfig, GenesisConfig,
 };
@@ -46,7 +46,7 @@ use zksync_node_framework::{
             main_node_strategy::MainNodeInitStrategyLayer, NodeStorageInitializerLayer,
         },
         object_store::ObjectStoreLayer,
-        pk_signing_eth_client::{PKSigningEthClientLayer, SigningEthClientType},
+        pk_signing_eth_client::PKSigningEthClientLayer,
         pools_layer::PoolsLayerBuilder,
         postgres::PostgresLayer,
         prometheus_exporter::PrometheusExporterLayer,
@@ -170,28 +170,11 @@ impl MainNodeBuilder {
         let eth_config = try_load_config!(self.configs.eth);
         let wallets = try_load_config!(self.wallets.eth_sender);
 
-        let eth_sender = self
-            .configs
-            .eth
-            .clone()
-            .context("eth_config")?
-            .sender
-            .context("sender")?;
-
-        let signing_mode = eth_sender.signing_mode.clone();
-        tracing::info!("Using signing mode: {:?}", signing_mode);
-
-        let client_type = match signing_mode {
-            SigningMode::GcloudKms => SigningEthClientType::GKMSSigningEthClient,
-            SigningMode::PrivateKey => SigningEthClientType::PKSigningEthClient,
-        };
-
         self.node.add_layer(PKSigningEthClientLayer::new(
             eth_config,
             self.contracts_config.clone(),
             self.gateway_chain_config.clone(),
             wallets,
-            client_type,
         ));
         Ok(self)
     }

--- a/core/lib/config/src/configs/eth_sender.rs
+++ b/core/lib/config/src/configs/eth_sender.rs
@@ -43,7 +43,6 @@ impl EthConfig {
                 tx_aggregation_only_prove_and_execute: false,
                 time_in_mempool_in_l1_blocks_cap: 1800,
                 is_verifier_pre_fflonk: true,
-                signing_mode: SigningMode::PrivateKey,
                 max_acceptable_base_fee_in_wei: 100000000000,
             }),
             gas_adjuster: Some(GasAdjusterConfig {
@@ -131,8 +130,6 @@ pub struct SenderConfig {
     #[serde(default = "SenderConfig::default_time_in_mempool_in_l1_blocks_cap")]
     pub time_in_mempool_in_l1_blocks_cap: u32,
     pub is_verifier_pre_fflonk: bool,
-    /// Type of signing client for Ethereum transactions.
-    pub signing_mode: SigningMode,
     /// Max acceptable base fee the sender is allowed to use to send L1 txs.
     pub max_acceptable_base_fee_in_wei: u64,
 }

--- a/core/lib/config/src/configs/wallets.rs
+++ b/core/lib/config/src/configs/wallets.rs
@@ -20,6 +20,7 @@ impl AddressWallet {
 pub struct Wallet {
     address: Address,
     private_key: K256PrivateKey,
+    zero_private_key: bool,
 }
 
 impl Wallet {
@@ -27,6 +28,7 @@ impl Wallet {
         Self {
             address: private_key.address(),
             private_key,
+            zero_private_key: false,
         }
     }
 
@@ -46,6 +48,17 @@ impl Wallet {
         Ok(Self {
             address: calculated_address,
             private_key,
+            zero_private_key: false,
+        })
+    }
+
+    pub fn ignore_private_key(address: Address) -> anyhow::Result<Self> {
+        let private_key = K256PrivateKey::random();
+
+        Ok(Self {
+            address,
+            private_key,
+            zero_private_key: true,
         })
     }
 

--- a/core/lib/config/src/configs/wallets.rs
+++ b/core/lib/config/src/configs/wallets.rs
@@ -20,6 +20,7 @@ impl AddressWallet {
 pub struct Wallet {
     address: Address,
     private_key: K256PrivateKey,
+    gkms_key_name: Option<String>,
 }
 
 impl Wallet {
@@ -27,6 +28,7 @@ impl Wallet {
         Self {
             address: private_key.address(),
             private_key,
+            gkms_key_name: None,
         }
     }
 
@@ -46,16 +48,16 @@ impl Wallet {
         Ok(Self {
             address: calculated_address,
             private_key,
+            gkms_key_name: None,
         })
     }
 
-    pub fn ignore_private_key(address: Address) -> anyhow::Result<Self> {
+    pub fn from_gkms_signer(address: Address, key_name: String) -> anyhow::Result<Self> {
         // we need to assign random private key for ignore_private_key wallets anyway to keep compatibility with existing systems
-        let private_key = K256PrivateKey::random();
-
         Ok(Self {
             address,
-            private_key,
+            private_key: K256PrivateKey::random(),
+            gkms_key_name: Some(key_name),
         })
     }
 
@@ -65,6 +67,10 @@ impl Wallet {
 
     pub fn private_key(&self) -> &K256PrivateKey {
         &self.private_key
+    }
+
+    pub fn gkms_key_name(&self) -> Option<String> {
+        self.gkms_key_name.clone()
     }
 }
 

--- a/core/lib/config/src/configs/wallets.rs
+++ b/core/lib/config/src/configs/wallets.rs
@@ -20,7 +20,6 @@ impl AddressWallet {
 pub struct Wallet {
     address: Address,
     private_key: K256PrivateKey,
-    ignore_private_key: bool,
 }
 
 impl Wallet {
@@ -28,7 +27,6 @@ impl Wallet {
         Self {
             address: private_key.address(),
             private_key,
-            ignore_private_key: false,
         }
     }
 
@@ -48,7 +46,6 @@ impl Wallet {
         Ok(Self {
             address: calculated_address,
             private_key,
-            ignore_private_key: false,
         })
     }
 
@@ -59,7 +56,6 @@ impl Wallet {
         Ok(Self {
             address,
             private_key,
-            ignore_private_key: true,
         })
     }
 

--- a/core/lib/config/src/configs/wallets.rs
+++ b/core/lib/config/src/configs/wallets.rs
@@ -20,7 +20,7 @@ impl AddressWallet {
 pub struct Wallet {
     address: Address,
     private_key: K256PrivateKey,
-    zero_private_key: bool,
+    ignore_private_key: bool,
 }
 
 impl Wallet {
@@ -28,7 +28,7 @@ impl Wallet {
         Self {
             address: private_key.address(),
             private_key,
-            zero_private_key: false,
+            ignore_private_key: false,
         }
     }
 
@@ -48,7 +48,7 @@ impl Wallet {
         Ok(Self {
             address: calculated_address,
             private_key,
-            zero_private_key: false,
+            ignore_private_key: false,
         })
     }
 
@@ -58,7 +58,7 @@ impl Wallet {
         Ok(Self {
             address,
             private_key,
-            zero_private_key: true,
+            ignore_private_key: true,
         })
     }
 

--- a/core/lib/config/src/configs/wallets.rs
+++ b/core/lib/config/src/configs/wallets.rs
@@ -53,6 +53,7 @@ impl Wallet {
     }
 
     pub fn ignore_private_key(address: Address) -> anyhow::Result<Self> {
+        // we need to assign random private key for ignore_private_key wallets anyway to keep compatibility with existing systems
         let private_key = K256PrivateKey::random();
 
         Ok(Self {

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -23,7 +23,6 @@ use crate::{
             avail::{AvailClientConfig, AvailDefaultConfig},
             DAClientConfig::Avail,
         },
-        eth_sender::SigningMode,
         external_price_api_client::ForcedPriceClientConfig,
     },
     AvailConfig,
@@ -421,7 +420,6 @@ impl Distribution<configs::eth_sender::SenderConfig> for EncodeDist {
             tx_aggregation_only_prove_and_execute: false,
             time_in_mempool_in_l1_blocks_cap: self.sample(rng),
             is_verifier_pre_fflonk: self.sample(rng),
-            signing_mode: SigningMode::PrivateKey,
             max_acceptable_base_fee_in_wei: self.sample(rng),
         }
     }

--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -76,7 +76,6 @@ mod tests {
                     tx_aggregation_paused: false,
                     time_in_mempool_in_l1_blocks_cap: 2000,
                     is_verifier_pre_fflonk: true,
-                    signing_mode: SigningMode::PrivateKey,
                     max_acceptable_base_fee_in_wei: 100_000_000_000,
                 }),
                 gas_adjuster: Some(GasAdjusterConfig {
@@ -144,7 +143,6 @@ mod tests {
             ETH_SENDER_SENDER_is_verifier_pre_fflonk="true"
             ETH_WATCH_CONFIRMATIONS_FOR_ETH_EVENT="0"
             ETH_WATCH_ETH_NODE_POLL_INTERVAL="300"
-            ETH_SENDER_SENDER_SIGNING_MODE="PrivateKey"
             ETH_CLIENT_WEB3_URL="http://127.0.0.1:8545"
             ETH_CLIENT_GATEWAY_WEB3_URL="http://127.0.0.1:8547"
             ETH_SENDER_SENDER_MAX_ACCEPTABLE_BASE_FEE_IN_WEI="100000000000"

--- a/core/lib/protobuf_config/src/eth.rs
+++ b/core/lib/protobuf_config/src/eth.rs
@@ -63,24 +63,6 @@ impl proto::SettlementMode {
     }
 }
 
-impl proto::SigningMode {
-    fn new(x: &configs::eth_sender::SigningMode) -> Self {
-        use configs::eth_sender::SigningMode as From;
-        match x {
-            From::PrivateKey => Self::PrivateKey,
-            From::GcloudKms => Self::GcloudKms,
-        }
-    }
-
-    fn parse(&self) -> configs::eth_sender::SigningMode {
-        use configs::eth_sender::SigningMode as To;
-        match self {
-            Self::PrivateKey => To::PrivateKey,
-            Self::GcloudKms => To::GcloudKms,
-        }
-    }
-}
-
 impl ProtoRepr for proto::Eth {
     type Type = configs::eth_sender::EthConfig;
 
@@ -147,10 +129,6 @@ impl ProtoRepr for proto::Sender {
                 .time_in_mempool_in_l1_blocks_cap
                 .unwrap_or(Self::Type::default_time_in_mempool_in_l1_blocks_cap()),
             is_verifier_pre_fflonk: self.is_verifier_pre_fflonk.unwrap_or(true),
-            signing_mode: required(&self.signing_mode)
-                .and_then(|x| Ok(proto::SigningMode::try_from(*x)?))
-                .context("signing_mode")?
-                .parse(),
             max_acceptable_base_fee_in_wei: *required(&self.max_acceptable_base_fee_in_wei)
                 .context("max_acceptable_base_fee_in_wei")?,
         })
@@ -182,7 +160,6 @@ impl ProtoRepr for proto::Sender {
             tx_aggregation_paused: Some(this.tx_aggregation_paused),
             time_in_mempool_in_l1_blocks_cap: Some(this.time_in_mempool_in_l1_blocks_cap),
             is_verifier_pre_fflonk: Some(this.is_verifier_pre_fflonk),
-            signing_mode: Some(proto::SigningMode::new(&this.signing_mode).into()),
             max_acceptable_base_fee_in_wei: Some(this.max_acceptable_base_fee_in_wei),
         }
     }

--- a/core/lib/protobuf_config/src/proto/config/eth_sender.proto
+++ b/core/lib/protobuf_config/src/proto/config/eth_sender.proto
@@ -61,7 +61,6 @@ message Sender {
   optional uint32 time_in_mempool_in_l1_blocks_cap = 22; // optional
   reserved 23; reserved "priority_op_start_index";
   optional bool is_verifier_pre_fflonk = 24; // optional
-  optional SigningMode signing_mode = 99; // required
   optional uint64 max_acceptable_base_fee_in_wei = 100; // required; wei
 }
 

--- a/core/lib/protobuf_config/src/proto/config/wallets.proto
+++ b/core/lib/protobuf_config/src/proto/config/wallets.proto
@@ -17,5 +17,4 @@ message Wallets {
   optional PrivateKeyWallet blob_operator = 2; // Private key is required
   optional AddressWallet fee_account = 3; // Only address required for server
   optional PrivateKeyWallet token_multiplier_setter = 4; // Private key is required
-  optional bool gkms_mode = 5; // optional
 }

--- a/core/lib/protobuf_config/src/proto/config/wallets.proto
+++ b/core/lib/protobuf_config/src/proto/config/wallets.proto
@@ -5,7 +5,7 @@ package zksync.config.wallets;
 message PrivateKeyWallet {
   optional string address = 1; // optional
   optional string private_key = 2; // required
-  optional bool zero_private_key = 3; // optional, this is hack for gkms_signer
+  optional bool ignore_private_key = 3; // optional, this is hack for gkms_signer
 }
 
 message AddressWallet {

--- a/core/lib/protobuf_config/src/proto/config/wallets.proto
+++ b/core/lib/protobuf_config/src/proto/config/wallets.proto
@@ -5,7 +5,7 @@ package zksync.config.wallets;
 message PrivateKeyWallet {
   optional string address = 1; // optional
   optional string private_key = 2; // required
-  optional bool ignore_private_key = 3; // optional, this is hack for gkms_signer
+  optional string gkms_key_name = 3; // optional
 }
 
 message AddressWallet {
@@ -17,4 +17,5 @@ message Wallets {
   optional PrivateKeyWallet blob_operator = 2; // Private key is required
   optional AddressWallet fee_account = 3; // Only address required for server
   optional PrivateKeyWallet token_multiplier_setter = 4; // Private key is required
+  optional bool gkms_mode = 5; // optional
 }

--- a/core/lib/protobuf_config/src/proto/config/wallets.proto
+++ b/core/lib/protobuf_config/src/proto/config/wallets.proto
@@ -5,6 +5,7 @@ package zksync.config.wallets;
 message PrivateKeyWallet {
   optional string address = 1; // optional
   optional string private_key = 2; // required
+  optional bool zero_private_key = 3; // optional, this is hack for gkms_signer
 }
 
 message AddressWallet {

--- a/core/lib/protobuf_config/src/wallets.rs
+++ b/core/lib/protobuf_config/src/wallets.rs
@@ -11,34 +11,33 @@ use crate::{parse_h160, parse_h256, proto::wallets as proto};
 impl ProtoRepr for proto::Wallets {
     type Type = configs::wallets::Wallets;
     fn read(&self) -> anyhow::Result<Self::Type> {
-        let gkms_mode = self.gkms_mode.unwrap_or(false);
         let eth_sender = if self.operator.is_some() && self.blob_operator.is_some() {
             let blob_operator = if let Some(blob_operator) = &self.blob_operator {
-                Some(if gkms_mode {
+                if let Some(gkms_key_name) = &blob_operator.gkms_key_name {
                     // will validate the address and the key name when init the gkms_eth_signer
-                    Wallet::from_gkms_signer(
+                    Some(Wallet::from_gkms_signer(
                         parse_h160(required(&blob_operator.address)?)?,
-                        required(&blob_operator.gkms_key_name)?.to_string(),
-                    )?
+                        gkms_key_name.to_string(),
+                    )?)
                 } else {
-                    Wallet::from_private_key_bytes(
+                    Some(Wallet::from_private_key_bytes(
                         parse_h256(required(&blob_operator.private_key).context("blob operator")?)?,
                         blob_operator
                             .address
                             .as_ref()
                             .and_then(|a| parse_h160(a).ok()),
-                    )?
-                })
+                    )?)
+                }
             } else {
                 None
             };
 
             let operator_wallet = &self.operator.clone().context("Operator private key")?;
 
-            let operator = if gkms_mode {
+            let operator = if let Some(gkms_key_name) = &operator_wallet.gkms_key_name {
                 Wallet::from_gkms_signer(
                     parse_h160(required(&operator_wallet.address)?)?,
-                    required(&operator_wallet.gkms_key_name)?.to_string(),
+                    gkms_key_name.to_string(),
                 )?
             } else {
                 Wallet::from_private_key_bytes(
@@ -141,7 +140,6 @@ impl ProtoRepr for proto::Wallets {
             operator,
             fee_account,
             token_multiplier_setter,
-            gkms_mode: Some(false),
         }
     }
 }

--- a/core/lib/protobuf_config/src/wallets.rs
+++ b/core/lib/protobuf_config/src/wallets.rs
@@ -11,11 +11,15 @@ use crate::{parse_h160, parse_h256, proto::wallets as proto};
 impl ProtoRepr for proto::Wallets {
     type Type = configs::wallets::Wallets;
     fn read(&self) -> anyhow::Result<Self::Type> {
+        let gkms_mode = self.gkms_mode.unwrap_or(false);
         let eth_sender = if self.operator.is_some() && self.blob_operator.is_some() {
             let blob_operator = if let Some(blob_operator) = &self.blob_operator {
-                let ignore_private_key = blob_operator.ignore_private_key.unwrap_or(false);
-                Some(if ignore_private_key {
-                    Wallet::ignore_private_key(parse_h160(required(&blob_operator.address)?)?)?
+                Some(if gkms_mode {
+                    // will validate the address and the key name when init the gkms_eth_signer
+                    Wallet::from_gkms_signer(
+                        parse_h160(required(&blob_operator.address)?)?,
+                        required(&blob_operator.gkms_key_name)?.to_string(),
+                    )?
                 } else {
                     Wallet::from_private_key_bytes(
                         parse_h256(required(&blob_operator.private_key).context("blob operator")?)?,
@@ -30,10 +34,12 @@ impl ProtoRepr for proto::Wallets {
             };
 
             let operator_wallet = &self.operator.clone().context("Operator private key")?;
-            let ignore_private_key = operator_wallet.ignore_private_key.unwrap_or(false);
 
-            let operator = if ignore_private_key {
-                Wallet::ignore_private_key(parse_h160(required(&operator_wallet.address)?)?)?
+            let operator = if gkms_mode {
+                Wallet::from_gkms_signer(
+                    parse_h160(required(&operator_wallet.address)?)?,
+                    required(&operator_wallet.gkms_key_name)?.to_string(),
+                )?
             } else {
                 Wallet::from_private_key_bytes(
                     parse_h256(required(&operator_wallet.private_key).context("operator")?)?,
@@ -93,7 +99,7 @@ impl ProtoRepr for proto::Wallets {
             proto::PrivateKeyWallet {
                 address: Some(format!("{:?}", addr)),
                 private_key: Some(hex::encode(pk.expose_secret().secret_bytes())),
-                ignore_private_key: Some(false),
+                gkms_key_name: None,
             }
         };
 
@@ -135,6 +141,7 @@ impl ProtoRepr for proto::Wallets {
             operator,
             fee_account,
             token_multiplier_setter,
+            gkms_mode: Some(false),
         }
     }
 }

--- a/core/lib/protobuf_config/src/wallets.rs
+++ b/core/lib/protobuf_config/src/wallets.rs
@@ -13,26 +13,36 @@ impl ProtoRepr for proto::Wallets {
     fn read(&self) -> anyhow::Result<Self::Type> {
         let eth_sender = if self.operator.is_some() && self.blob_operator.is_some() {
             let blob_operator = if let Some(blob_operator) = &self.blob_operator {
-                Some(Wallet::from_private_key_bytes(
-                    parse_h256(required(&blob_operator.private_key).context("blob operator")?)?,
-                    blob_operator
-                        .address
-                        .as_ref()
-                        .and_then(|a| parse_h160(a).ok()),
-                )?)
+                let zero_private_key = blob_operator.zero_private_key.unwrap_or(false);
+                Some(if zero_private_key {
+                    Wallet::ignore_private_key(parse_h160(required(&blob_operator.address)?)?)?
+                } else {
+                    Wallet::from_private_key_bytes(
+                        parse_h256(required(&blob_operator.private_key).context("blob operator")?)?,
+                        blob_operator
+                            .address
+                            .as_ref()
+                            .and_then(|a| parse_h160(a).ok()),
+                    )?
+                })
             } else {
                 None
             };
 
             let operator_wallet = &self.operator.clone().context("Operator private key")?;
+            let zero_private_key = operator_wallet.zero_private_key.unwrap_or(false);
 
-            let operator = Wallet::from_private_key_bytes(
-                parse_h256(required(&operator_wallet.private_key).context("operator")?)?,
-                operator_wallet
-                    .address
-                    .as_ref()
-                    .and_then(|a| parse_h160(a).ok()),
-            )?;
+            let operator = if zero_private_key {
+                Wallet::ignore_private_key(parse_h160(required(&operator_wallet.address)?)?)?
+            } else {
+                Wallet::from_private_key_bytes(
+                    parse_h256(required(&operator_wallet.private_key).context("operator")?)?,
+                    operator_wallet
+                        .address
+                        .as_ref()
+                        .and_then(|a| parse_h160(a).ok()),
+                )?
+            };
 
             Some(EthSender {
                 operator,
@@ -83,6 +93,7 @@ impl ProtoRepr for proto::Wallets {
             proto::PrivateKeyWallet {
                 address: Some(format!("{:?}", addr)),
                 private_key: Some(hex::encode(pk.expose_secret().secret_bytes())),
+                zero_private_key: Some(false),
             }
         };
 

--- a/core/lib/protobuf_config/src/wallets.rs
+++ b/core/lib/protobuf_config/src/wallets.rs
@@ -13,8 +13,8 @@ impl ProtoRepr for proto::Wallets {
     fn read(&self) -> anyhow::Result<Self::Type> {
         let eth_sender = if self.operator.is_some() && self.blob_operator.is_some() {
             let blob_operator = if let Some(blob_operator) = &self.blob_operator {
-                let zero_private_key = blob_operator.zero_private_key.unwrap_or(false);
-                Some(if zero_private_key {
+                let ignore_private_key = blob_operator.ignore_private_key.unwrap_or(false);
+                Some(if ignore_private_key {
                     Wallet::ignore_private_key(parse_h160(required(&blob_operator.address)?)?)?
                 } else {
                     Wallet::from_private_key_bytes(
@@ -30,9 +30,9 @@ impl ProtoRepr for proto::Wallets {
             };
 
             let operator_wallet = &self.operator.clone().context("Operator private key")?;
-            let zero_private_key = operator_wallet.zero_private_key.unwrap_or(false);
+            let ignore_private_key = operator_wallet.ignore_private_key.unwrap_or(false);
 
-            let operator = if zero_private_key {
+            let operator = if ignore_private_key {
                 Wallet::ignore_private_key(parse_h160(required(&operator_wallet.address)?)?)?
             } else {
                 Wallet::from_private_key_bytes(
@@ -93,7 +93,7 @@ impl ProtoRepr for proto::Wallets {
             proto::PrivateKeyWallet {
                 address: Some(format!("{:?}", addr)),
                 private_key: Some(hex::encode(pk.expose_secret().secret_bytes())),
-                zero_private_key: Some(false),
+                ignore_private_key: Some(false),
             }
         };
 

--- a/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
+++ b/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
@@ -80,132 +80,144 @@ impl WiringLayer for PKSigningEthClientLayer {
             .await
             .map_err(WiringError::internal)?;
 
-        let signing_client;
-        let signing_client_for_gateway;
-        let mut signing_client_for_blobs = None;
+        let (signing_client, signing_client_for_blobs, signing_client_for_gateway) =
+            if let Some(gkms_op_key_name) = self.wallets.operator.gkms_key_name() {
+                tracing::info!("KMS op key name in wallet: {:?}", gkms_op_key_name);
 
-        // if the wallet.yaml has gkms key setup for operator, will use it instead of using the gkms settings in env
-        if let Some(gkms_op_key_name) = self.wallets.operator.gkms_key_name() {
-            tracing::info!("KMS op key name in wallet: {:?}", gkms_op_key_name);
+                let sc = GKMSSigningClient::new_raw(
+                    self.contracts_config.diamond_proxy_addr,
+                    gas_adjuster_config.default_priority_fee_per_gas,
+                    l1_chain_id,
+                    query_client.clone(),
+                    gkms_op_key_name.clone(),
+                )
+                .await;
 
-            let sc = GKMSSigningClient::new_raw(
-                self.contracts_config.diamond_proxy_addr,
-                gas_adjuster_config.default_priority_fee_per_gas,
-                l1_chain_id,
-                query_client.clone(),
-                gkms_op_key_name.clone(),
-            )
-            .await;
-
-            let op_address = self.wallets.operator.address();
-            if sc.get_address() != op_address {
-                return Err(WiringError::internal(anyhow::anyhow!(
-                    "Operator address mismatch: expected {}, got {}",
-                    op_address,
-                    sc.get_address()
-                )));
-            }
-
-            signing_client = BoundEthInterfaceResource(Box::new(sc));
-
-            if let Some(blob_operator) = self.wallets.blob_operator {
-                if let Some(gkms_op_blob_key_name) = blob_operator.gkms_key_name() {
-                    tracing::info!(
-                        "KMS op blob key name in wallet: {:?}",
-                        gkms_op_blob_key_name
-                    );
-
-                    let blobs_resources = GKMSSigningClient::new_raw(
-                        self.contracts_config.diamond_proxy_addr,
-                        gas_adjuster_config.default_priority_fee_per_gas,
-                        l1_chain_id,
-                        query_client,
-                        gkms_op_blob_key_name.clone(),
-                    )
-                    .await;
-
-                    if blobs_resources.get_address() != blob_operator.address() {
-                        return Err(WiringError::internal(anyhow::anyhow!(
-                            "Blob operator address mismatch: expected {}, got {}",
-                            blob_operator.address(),
-                            blobs_resources.get_address()
-                        )));
-                    }
-
-                    signing_client_for_blobs =
-                        Some(BoundEthInterfaceForBlobsResource(Box::new(blobs_resources)));
+                let op_address = self.wallets.operator.address();
+                if sc.get_address() != op_address {
+                    return Err(WiringError::internal(anyhow::anyhow!(
+                        "Operator address mismatch: expected {}, got {}",
+                        op_address,
+                        sc.get_address()
+                    )));
                 }
-            }
 
-            signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
-                (&input.gateway_client, self.gateway_chain_config.as_ref())
-            {
-                if gateway_contracts.gateway_chain_id.0 != 0u64 {
-                    let GatewayEthInterfaceResource(gateway_client) = client;
-                    let signing_client_for_gateway = GKMSSigningClient::new_raw(
-                        gateway_contracts.diamond_proxy_addr,
-                        gas_adjuster_config.default_priority_fee_per_gas,
-                        gateway_contracts.gateway_chain_id,
-                        gateway_client.clone(),
-                        gkms_op_key_name,
-                    )
-                    .await;
+                let signing_client = BoundEthInterfaceResource(Box::new(sc));
 
-                    Some(BoundEthInterfaceForL2Resource(Box::new(
-                        signing_client_for_gateway,
-                    )))
+                let signing_client_for_blobs =
+                    if let Some(blob_operator) = self.wallets.blob_operator {
+                        if let Some(gkms_op_blob_key_name) = blob_operator.gkms_key_name() {
+                            tracing::info!(
+                                "KMS op blob key name in wallet: {:?}",
+                                gkms_op_blob_key_name
+                            );
+
+                            let blobs_resources = GKMSSigningClient::new_raw(
+                                self.contracts_config.diamond_proxy_addr,
+                                gas_adjuster_config.default_priority_fee_per_gas,
+                                l1_chain_id,
+                                query_client,
+                                gkms_op_blob_key_name.clone(),
+                            )
+                            .await;
+
+                            if blobs_resources.get_address() != blob_operator.address() {
+                                return Err(WiringError::internal(anyhow::anyhow!(
+                                    "Blob operator address mismatch: expected {}, got {}",
+                                    blob_operator.address(),
+                                    blobs_resources.get_address()
+                                )));
+                            }
+
+                            Some(BoundEthInterfaceForBlobsResource(Box::new(blobs_resources)))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
+                let signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
+                    (&input.gateway_client, self.gateway_chain_config.as_ref())
+                {
+                    if gateway_contracts.gateway_chain_id.0 != 0u64 {
+                        let GatewayEthInterfaceResource(gateway_client) = client;
+                        let signing_client_for_gateway = GKMSSigningClient::new_raw(
+                            gateway_contracts.diamond_proxy_addr,
+                            gas_adjuster_config.default_priority_fee_per_gas,
+                            gateway_contracts.gateway_chain_id,
+                            gateway_client.clone(),
+                            gkms_op_key_name,
+                        )
+                        .await;
+
+                        Some(BoundEthInterfaceForL2Resource(Box::new(
+                            signing_client_for_gateway,
+                        )))
+                    } else {
+                        None
+                    }
                 } else {
                     None
-                }
+                };
+
+                (
+                    signing_client,
+                    signing_client_for_blobs,
+                    signing_client_for_gateway,
+                )
             } else {
-                None
-            };
-        } else {
-            let private_key = self.wallets.operator.private_key();
+                let private_key = self.wallets.operator.private_key();
 
-            let sc = PKSigningClient::new_raw(
-                private_key.clone(),
-                self.contracts_config.diamond_proxy_addr,
-                gas_adjuster_config.default_priority_fee_per_gas,
-                l1_chain_id,
-                query_client.clone(),
-            );
-            signing_client = BoundEthInterfaceResource(Box::new(sc));
-
-            signing_client_for_blobs = self.wallets.blob_operator.map(|blob_operator| {
-                let private_key = blob_operator.private_key();
-                let signing_client_for_blobs = PKSigningClient::new_raw(
+                let sc = PKSigningClient::new_raw(
                     private_key.clone(),
                     self.contracts_config.diamond_proxy_addr,
                     gas_adjuster_config.default_priority_fee_per_gas,
                     l1_chain_id,
-                    query_client,
+                    query_client.clone(),
                 );
-                BoundEthInterfaceForBlobsResource(Box::new(signing_client_for_blobs))
-            });
+                let signing_client = BoundEthInterfaceResource(Box::new(sc));
 
-            signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
-                (&input.gateway_client, self.gateway_chain_config.as_ref())
-            {
-                if gateway_contracts.gateway_chain_id.0 != 0u64 {
-                    let GatewayEthInterfaceResource(gateway_client) = client;
-                    let signing_client_for_gateway = PKSigningClient::new_raw(
+                let signing_client_for_blobs = self.wallets.blob_operator.map(|blob_operator| {
+                    let private_key = blob_operator.private_key();
+                    let signing_client_for_blobs = PKSigningClient::new_raw(
                         private_key.clone(),
-                        gateway_contracts.diamond_proxy_addr,
+                        self.contracts_config.diamond_proxy_addr,
                         gas_adjuster_config.default_priority_fee_per_gas,
-                        gateway_contracts.gateway_chain_id,
-                        gateway_client.clone(),
+                        l1_chain_id,
+                        query_client,
                     );
-                    Some(BoundEthInterfaceForL2Resource(Box::new(
-                        signing_client_for_gateway,
-                    )))
+                    BoundEthInterfaceForBlobsResource(Box::new(signing_client_for_blobs))
+                });
+
+                let signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
+                    (&input.gateway_client, self.gateway_chain_config.as_ref())
+                {
+                    if gateway_contracts.gateway_chain_id.0 != 0u64 {
+                        let GatewayEthInterfaceResource(gateway_client) = client;
+                        let signing_client_for_gateway = PKSigningClient::new_raw(
+                            private_key.clone(),
+                            gateway_contracts.diamond_proxy_addr,
+                            gas_adjuster_config.default_priority_fee_per_gas,
+                            gateway_contracts.gateway_chain_id,
+                            gateway_client.clone(),
+                        );
+                        Some(BoundEthInterfaceForL2Resource(Box::new(
+                            signing_client_for_gateway,
+                        )))
+                    } else {
+                        None
+                    }
                 } else {
                     None
-                }
-            } else {
-                None
+                };
+
+                (
+                    signing_client,
+                    signing_client_for_blobs,
+                    signing_client_for_gateway,
+                )
             };
-        }
 
         Ok(Output {
             signing_client,

--- a/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
+++ b/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
@@ -94,120 +94,198 @@ impl WiringLayer for PKSigningEthClientLayer {
         let signing_client_for_gateway;
         let mut signing_client_for_blobs = None;
 
-        match self.client_type {
-            SigningEthClientType::PKSigningEthClient => {
-                let private_key = self.wallets.operator.private_key();
+        // if the wallet.yaml has gkms key setup for operator, will use it instead of using the gkms settings in env
+        if let Some(gkms_op_key_name) = self.wallets.operator.gkms_key_name() {
+            tracing::info!("KMS op key name in wallet: {:?}", gkms_op_key_name);
 
-                let sc = PKSigningClient::new_raw(
-                    private_key.clone(),
-                    self.contracts_config.diamond_proxy_addr,
-                    gas_adjuster_config.default_priority_fee_per_gas,
-                    l1_chain_id,
-                    query_client.clone(),
-                );
-                signing_client = BoundEthInterfaceResource(Box::new(sc));
+            let sc = GKMSSigningClient::new_raw(
+                self.contracts_config.diamond_proxy_addr,
+                gas_adjuster_config.default_priority_fee_per_gas,
+                l1_chain_id,
+                query_client.clone(),
+                gkms_op_key_name.clone(),
+            )
+            .await;
 
-                signing_client_for_blobs = self.wallets.blob_operator.map(|blob_operator| {
-                    let private_key = blob_operator.private_key();
-                    let signing_client_for_blobs = PKSigningClient::new_raw(
-                        private_key.clone(),
-                        self.contracts_config.diamond_proxy_addr,
-                        gas_adjuster_config.default_priority_fee_per_gas,
-                        l1_chain_id,
-                        query_client,
-                    );
-                    BoundEthInterfaceForBlobsResource(Box::new(signing_client_for_blobs))
-                });
-
-                signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
-                    (&input.gateway_client, self.gateway_chain_config.as_ref())
-                {
-                    if gateway_contracts.gateway_chain_id.0 != 0u64 {
-                        let GatewayEthInterfaceResource(gateway_client) = client;
-                        let signing_client_for_gateway = PKSigningClient::new_raw(
-                            private_key.clone(),
-                            gateway_contracts.diamond_proxy_addr,
-                            gas_adjuster_config.default_priority_fee_per_gas,
-                            gateway_contracts.gateway_chain_id,
-                            gateway_client.clone(),
-                        );
-                        Some(BoundEthInterfaceForL2Resource(Box::new(
-                            signing_client_for_gateway,
-                        )))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
+            let op_address = self.wallets.operator.address();
+            if sc.get_address() != op_address {
+                return Err(WiringError::internal(anyhow::anyhow!(
+                    "Operator address mismatch: expected {}, got {}",
+                    op_address,
+                    sc.get_address()
+                )));
             }
-            SigningEthClientType::GKMSSigningEthClient => {
-                let gkms_op_key_name = std::env::var("GOOGLE_KMS_OP_KEY_NAME").ok();
-                tracing::info!(
-                    "KMS op key name: {:?}",
-                    std::env::var("GOOGLE_KMS_OP_KEY_NAME")
-                );
 
-                let sc = GKMSSigningClient::new_raw(
-                    self.contracts_config.diamond_proxy_addr,
-                    gas_adjuster_config.default_priority_fee_per_gas,
-                    l1_chain_id,
-                    query_client.clone(),
-                    gkms_op_key_name
-                        .clone()
-                        .expect("gkms_op_key_name is required but was None")
-                        .to_string(),
-                )
-                .await;
+            signing_client = BoundEthInterfaceResource(Box::new(sc));
 
-                signing_client = BoundEthInterfaceResource(Box::new(sc));
+            if let Some(blob_operator) = self.wallets.blob_operator {
+                if let Some(gkms_op_blob_key_name) = blob_operator.gkms_key_name() {
+                    tracing::info!(
+                        "KMS op blob key name in wallet: {:?}",
+                        gkms_op_blob_key_name
+                    );
 
-                let gkms_op_blob_key_name = std::env::var("GOOGLE_KMS_OP_BLOB_KEY_NAME").ok();
-                tracing::info!(
-                    "KMS op blob key name: {:?}",
-                    std::env::var("GOOGLE_KMS_OP_BLOB_KEY_NAME")
-                );
-
-                if let Some(key_name) = gkms_op_blob_key_name {
                     let blobs_resources = GKMSSigningClient::new_raw(
                         self.contracts_config.diamond_proxy_addr,
                         gas_adjuster_config.default_priority_fee_per_gas,
                         l1_chain_id,
                         query_client,
-                        key_name.to_string(),
+                        gkms_op_blob_key_name.clone(),
                     )
                     .await;
+
+                    if blobs_resources.get_address() != blob_operator.address() {
+                        return Err(WiringError::internal(anyhow::anyhow!(
+                            "Blob operator address mismatch: expected {}, got {}",
+                            blob_operator.address(),
+                            blobs_resources.get_address()
+                        )));
+                    }
+
                     signing_client_for_blobs =
                         Some(BoundEthInterfaceForBlobsResource(Box::new(blobs_resources)));
-                };
+                }
+            }
 
-                signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
-                    (&input.gateway_client, self.gateway_chain_config.as_ref())
-                {
-                    if gateway_contracts.gateway_chain_id.0 != 0u64 {
-                        let GatewayEthInterfaceResource(gateway_client) = client;
-                        let signing_client_for_gateway = GKMSSigningClient::new_raw(
-                            gateway_contracts.diamond_proxy_addr,
-                            gas_adjuster_config.default_priority_fee_per_gas,
-                            gateway_contracts.gateway_chain_id,
-                            gateway_client.clone(),
-                            gkms_op_key_name
-                                .expect("gkms_op_key_name is required but was None")
-                                .to_string(),
-                        )
-                        .await;
+            signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
+                (&input.gateway_client, self.gateway_chain_config.as_ref())
+            {
+                if gateway_contracts.gateway_chain_id.0 != 0u64 {
+                    let GatewayEthInterfaceResource(gateway_client) = client;
+                    let signing_client_for_gateway = GKMSSigningClient::new_raw(
+                        gateway_contracts.diamond_proxy_addr,
+                        gas_adjuster_config.default_priority_fee_per_gas,
+                        gateway_contracts.gateway_chain_id,
+                        gateway_client.clone(),
+                        gkms_op_key_name,
+                    )
+                    .await;
 
-                        Some(BoundEthInterfaceForL2Resource(Box::new(
-                            signing_client_for_gateway,
-                        )))
-                    } else {
-                        None
-                    }
+                    Some(BoundEthInterfaceForL2Resource(Box::new(
+                        signing_client_for_gateway,
+                    )))
                 } else {
                     None
-                };
-            }
-        };
+                }
+            } else {
+                None
+            };
+        } else {
+            match self.client_type {
+                SigningEthClientType::PKSigningEthClient => {
+                    let private_key = self.wallets.operator.private_key();
+
+                    let sc = PKSigningClient::new_raw(
+                        private_key.clone(),
+                        self.contracts_config.diamond_proxy_addr,
+                        gas_adjuster_config.default_priority_fee_per_gas,
+                        l1_chain_id,
+                        query_client.clone(),
+                    );
+                    signing_client = BoundEthInterfaceResource(Box::new(sc));
+
+                    signing_client_for_blobs = self.wallets.blob_operator.map(|blob_operator| {
+                        let private_key = blob_operator.private_key();
+                        let signing_client_for_blobs = PKSigningClient::new_raw(
+                            private_key.clone(),
+                            self.contracts_config.diamond_proxy_addr,
+                            gas_adjuster_config.default_priority_fee_per_gas,
+                            l1_chain_id,
+                            query_client,
+                        );
+                        BoundEthInterfaceForBlobsResource(Box::new(signing_client_for_blobs))
+                    });
+
+                    signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
+                        (&input.gateway_client, self.gateway_chain_config.as_ref())
+                    {
+                        if gateway_contracts.gateway_chain_id.0 != 0u64 {
+                            let GatewayEthInterfaceResource(gateway_client) = client;
+                            let signing_client_for_gateway = PKSigningClient::new_raw(
+                                private_key.clone(),
+                                gateway_contracts.diamond_proxy_addr,
+                                gas_adjuster_config.default_priority_fee_per_gas,
+                                gateway_contracts.gateway_chain_id,
+                                gateway_client.clone(),
+                            );
+                            Some(BoundEthInterfaceForL2Resource(Box::new(
+                                signing_client_for_gateway,
+                            )))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                }
+                SigningEthClientType::GKMSSigningEthClient => {
+                    let gkms_op_key_name = std::env::var("GOOGLE_KMS_OP_KEY_NAME").ok();
+                    tracing::info!(
+                        "KMS op key name: {:?}",
+                        std::env::var("GOOGLE_KMS_OP_KEY_NAME")
+                    );
+
+                    let sc = GKMSSigningClient::new_raw(
+                        self.contracts_config.diamond_proxy_addr,
+                        gas_adjuster_config.default_priority_fee_per_gas,
+                        l1_chain_id,
+                        query_client.clone(),
+                        gkms_op_key_name
+                            .clone()
+                            .expect("gkms_op_key_name is required but was None")
+                            .to_string(),
+                    )
+                    .await;
+
+                    signing_client = BoundEthInterfaceResource(Box::new(sc));
+
+                    let gkms_op_blob_key_name = std::env::var("GOOGLE_KMS_OP_BLOB_KEY_NAME").ok();
+                    tracing::info!(
+                        "KMS op blob key name: {:?}",
+                        std::env::var("GOOGLE_KMS_OP_BLOB_KEY_NAME")
+                    );
+
+                    if let Some(key_name) = gkms_op_blob_key_name {
+                        let blobs_resources = GKMSSigningClient::new_raw(
+                            self.contracts_config.diamond_proxy_addr,
+                            gas_adjuster_config.default_priority_fee_per_gas,
+                            l1_chain_id,
+                            query_client,
+                            key_name.to_string(),
+                        )
+                        .await;
+                        signing_client_for_blobs =
+                            Some(BoundEthInterfaceForBlobsResource(Box::new(blobs_resources)));
+                    };
+
+                    signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
+                        (&input.gateway_client, self.gateway_chain_config.as_ref())
+                    {
+                        if gateway_contracts.gateway_chain_id.0 != 0u64 {
+                            let GatewayEthInterfaceResource(gateway_client) = client;
+                            let signing_client_for_gateway = GKMSSigningClient::new_raw(
+                                gateway_contracts.diamond_proxy_addr,
+                                gas_adjuster_config.default_priority_fee_per_gas,
+                                gateway_contracts.gateway_chain_id,
+                                gateway_client.clone(),
+                                gkms_op_key_name
+                                    .expect("gkms_op_key_name is required but was None")
+                                    .to_string(),
+                            )
+                            .await;
+
+                            Some(BoundEthInterfaceForL2Resource(Box::new(
+                                signing_client_for_gateway,
+                            )))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                }
+            };
+        }
 
         Ok(Output {
             signing_client,

--- a/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
+++ b/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
@@ -19,19 +19,11 @@ use crate::{
 
 /// Wiring layer for [`PKSigningClient`].
 #[derive(Debug)]
-#[non_exhaustive]
-pub enum SigningEthClientType {
-    PKSigningEthClient,
-    GKMSSigningEthClient,
-}
-
-#[derive(Debug)]
 pub struct PKSigningEthClientLayer {
     eth_sender_config: EthConfig,
     contracts_config: ContractsConfig,
     gateway_chain_config: Option<GatewayChainConfig>,
     wallets: wallets::EthSender,
-    client_type: SigningEthClientType,
 }
 
 #[derive(Debug, FromContext)]
@@ -56,14 +48,12 @@ impl PKSigningEthClientLayer {
         contracts_config: ContractsConfig,
         gateway_chain_config: Option<GatewayChainConfig>,
         wallets: wallets::EthSender,
-        client_type: SigningEthClientType,
     ) -> Self {
         Self {
             eth_sender_config,
             contracts_config,
             gateway_chain_config,
             wallets,
-            client_type,
         }
     }
 }
@@ -171,119 +161,49 @@ impl WiringLayer for PKSigningEthClientLayer {
                 None
             };
         } else {
-            match self.client_type {
-                SigningEthClientType::PKSigningEthClient => {
-                    let private_key = self.wallets.operator.private_key();
+            let private_key = self.wallets.operator.private_key();
 
-                    let sc = PKSigningClient::new_raw(
+            let sc = PKSigningClient::new_raw(
+                private_key.clone(),
+                self.contracts_config.diamond_proxy_addr,
+                gas_adjuster_config.default_priority_fee_per_gas,
+                l1_chain_id,
+                query_client.clone(),
+            );
+            signing_client = BoundEthInterfaceResource(Box::new(sc));
+
+            signing_client_for_blobs = self.wallets.blob_operator.map(|blob_operator| {
+                let private_key = blob_operator.private_key();
+                let signing_client_for_blobs = PKSigningClient::new_raw(
+                    private_key.clone(),
+                    self.contracts_config.diamond_proxy_addr,
+                    gas_adjuster_config.default_priority_fee_per_gas,
+                    l1_chain_id,
+                    query_client,
+                );
+                BoundEthInterfaceForBlobsResource(Box::new(signing_client_for_blobs))
+            });
+
+            signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
+                (&input.gateway_client, self.gateway_chain_config.as_ref())
+            {
+                if gateway_contracts.gateway_chain_id.0 != 0u64 {
+                    let GatewayEthInterfaceResource(gateway_client) = client;
+                    let signing_client_for_gateway = PKSigningClient::new_raw(
                         private_key.clone(),
-                        self.contracts_config.diamond_proxy_addr,
+                        gateway_contracts.diamond_proxy_addr,
                         gas_adjuster_config.default_priority_fee_per_gas,
-                        l1_chain_id,
-                        query_client.clone(),
+                        gateway_contracts.gateway_chain_id,
+                        gateway_client.clone(),
                     );
-                    signing_client = BoundEthInterfaceResource(Box::new(sc));
-
-                    signing_client_for_blobs = self.wallets.blob_operator.map(|blob_operator| {
-                        let private_key = blob_operator.private_key();
-                        let signing_client_for_blobs = PKSigningClient::new_raw(
-                            private_key.clone(),
-                            self.contracts_config.diamond_proxy_addr,
-                            gas_adjuster_config.default_priority_fee_per_gas,
-                            l1_chain_id,
-                            query_client,
-                        );
-                        BoundEthInterfaceForBlobsResource(Box::new(signing_client_for_blobs))
-                    });
-
-                    signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
-                        (&input.gateway_client, self.gateway_chain_config.as_ref())
-                    {
-                        if gateway_contracts.gateway_chain_id.0 != 0u64 {
-                            let GatewayEthInterfaceResource(gateway_client) = client;
-                            let signing_client_for_gateway = PKSigningClient::new_raw(
-                                private_key.clone(),
-                                gateway_contracts.diamond_proxy_addr,
-                                gas_adjuster_config.default_priority_fee_per_gas,
-                                gateway_contracts.gateway_chain_id,
-                                gateway_client.clone(),
-                            );
-                            Some(BoundEthInterfaceForL2Resource(Box::new(
-                                signing_client_for_gateway,
-                            )))
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
+                    Some(BoundEthInterfaceForL2Resource(Box::new(
+                        signing_client_for_gateway,
+                    )))
+                } else {
+                    None
                 }
-                SigningEthClientType::GKMSSigningEthClient => {
-                    let gkms_op_key_name = std::env::var("GOOGLE_KMS_OP_KEY_NAME").ok();
-                    tracing::info!(
-                        "KMS op key name: {:?}",
-                        std::env::var("GOOGLE_KMS_OP_KEY_NAME")
-                    );
-
-                    let sc = GKMSSigningClient::new_raw(
-                        self.contracts_config.diamond_proxy_addr,
-                        gas_adjuster_config.default_priority_fee_per_gas,
-                        l1_chain_id,
-                        query_client.clone(),
-                        gkms_op_key_name
-                            .clone()
-                            .expect("gkms_op_key_name is required but was None")
-                            .to_string(),
-                    )
-                    .await;
-
-                    signing_client = BoundEthInterfaceResource(Box::new(sc));
-
-                    let gkms_op_blob_key_name = std::env::var("GOOGLE_KMS_OP_BLOB_KEY_NAME").ok();
-                    tracing::info!(
-                        "KMS op blob key name: {:?}",
-                        std::env::var("GOOGLE_KMS_OP_BLOB_KEY_NAME")
-                    );
-
-                    if let Some(key_name) = gkms_op_blob_key_name {
-                        let blobs_resources = GKMSSigningClient::new_raw(
-                            self.contracts_config.diamond_proxy_addr,
-                            gas_adjuster_config.default_priority_fee_per_gas,
-                            l1_chain_id,
-                            query_client,
-                            key_name.to_string(),
-                        )
-                        .await;
-                        signing_client_for_blobs =
-                            Some(BoundEthInterfaceForBlobsResource(Box::new(blobs_resources)));
-                    };
-
-                    signing_client_for_gateway = if let (Some(client), Some(gateway_contracts)) =
-                        (&input.gateway_client, self.gateway_chain_config.as_ref())
-                    {
-                        if gateway_contracts.gateway_chain_id.0 != 0u64 {
-                            let GatewayEthInterfaceResource(gateway_client) = client;
-                            let signing_client_for_gateway = GKMSSigningClient::new_raw(
-                                gateway_contracts.diamond_proxy_addr,
-                                gas_adjuster_config.default_priority_fee_per_gas,
-                                gateway_contracts.gateway_chain_id,
-                                gateway_client.clone(),
-                                gkms_op_key_name
-                                    .expect("gkms_op_key_name is required but was None")
-                                    .to_string(),
-                            )
-                            .await;
-
-                            Some(BoundEthInterfaceForL2Resource(Box::new(
-                                signing_client_for_gateway,
-                            )))
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
-                }
+            } else {
+                None
             };
         }
 

--- a/etc/env/base/eth_sender.toml
+++ b/etc/env/base/eth_sender.toml
@@ -50,8 +50,6 @@ pubdata_sending_mode = "Blobs"
 
 is_verifier_pre_fflonk = true
 
-signing_mode = "PrivateKey"
-
 # Max acceptable base fee for sending tx to L1
 max_acceptable_base_fee_in_wei = 1000000000000
 

--- a/etc/env/file_based/general.yaml
+++ b/etc/env/file_based/general.yaml
@@ -105,7 +105,6 @@ eth:
     max_acceptable_priority_fee_in_gwei: 100000000000 # typo: value is in wei (100 gwei)
     pubdata_sending_mode: BLOBS
     is_verifier_pre_fflonk: true
-    signing_mode: PRIVATE_KEY
     max_acceptable_base_fee_in_wei: 100000000000
   gas_adjuster:
     default_priority_fee_per_gas: 1000000000


### PR DESCRIPTION
If we execute zkserver with the `wallet.yaml` file, it will cause the yaml reading failed due to  we don't wont to expose the operator's private key info to the server. Therefore, this patch add a flag into the wallet struct to let the wallet can just load the operator's address without providing the private key info. I.e.

Original setup in `wallet.yaml`
```
operator:
  address: ...
  private_key: ...

blob_operator:
  address: ...
  private_key: ...

other field...
```

In this PR, you should remove the `private_key` field and add `gkms_key_name` field
```
operator:
  address: ...
  gkms_key_name: PATH_TO_GKMS_KEY

blob_operator:
  address: ...
  gkms_key_name: PATH_TO_GKMS_KEY

other field... (the same)
```